### PR TITLE
Move initial max_migration.txt creation into create-max-migration-fil…

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,9 @@
 History
 =======
 
+* Move initial ``max_migration.txt`` file creation into a separate management
+  command, ``create-max-migration-files``.
+
 1.0.0 (2020-12-10)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ Third, run this one-off command for installation:
 
 .. code-block:: sh
 
-    python manage.py makemigrations --create-max-migration-files
+    python manage.py create-max-migration-files
 
 This creates a new ``max_migration.txt`` file in each of your first-party apps’ ``migrations`` directories and exits.
 More on those files below...

--- a/src/django_linear_migrations/apps.py
+++ b/src/django_linear_migrations/apps.py
@@ -73,7 +73,7 @@ class MigrationDetails:
 dlm_E001_msg = "{app_label}'s max_migration.txt does not exist."
 dlm_E001_hint = (
     "If you just installed django-linear-migrations, run 'python manage.py"
-    + " makemigrations --initialize-max-migrations'. Otherwise, check how it"
+    + " makemigrations --create-max-migrations'. Otherwise, check how it"
     + " has gone missing."
 )
 

--- a/src/django_linear_migrations/management/commands/create-max-migration-files.py
+++ b/src/django_linear_migrations/management/commands/create-max-migration-files.py
@@ -1,0 +1,56 @@
+import sys
+
+from django.apps import apps
+from django.core.management.commands.makemigrations import Command as BaseCommand
+
+from django_linear_migrations.apps import MigrationDetails, first_party_app_configs
+
+
+class Command(BaseCommand):
+    help = (
+        "Generate max_migration.txt files for first-party apps that don't"
+        + " have one."
+    )
+
+    # Checks disabled because the django-linear-migrations' checks would
+    # prevent us continuing
+    requires_system_checks = False
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "args",
+            metavar="app_label",
+            nargs="*",
+            help="Specify the app label(s) to create max migration files for.",
+        )
+
+    def handle(self, *app_labels, **options):
+        # Copied check from makemigrations
+        app_labels = set(app_labels)
+        has_bad_labels = False
+        for app_label in app_labels:
+            try:
+                apps.get_app_config(app_label)
+            except LookupError as err:
+                self.stderr.write(str(err))
+                has_bad_labels = True
+        if has_bad_labels:
+            sys.exit(2)
+
+        any_created = False
+        for app_config in first_party_app_configs():
+            if app_labels and app_config.label not in app_labels:
+                continue
+
+            migration_details = MigrationDetails(app_config.label)
+            max_migration_txt = migration_details.dir / "max_migration.txt"
+            if not max_migration_txt.exists():
+                max_migration_name = max(migration_details.names)
+                max_migration_txt.write_text(max_migration_name + "\n")
+                self.stdout.write(
+                    "Created max_migration.txt for {}".format(app_config.label)
+                )
+                any_created = True
+
+        if not any_created:
+            self.stdout.write("No max_migration.txt files need creating.")

--- a/src/django_linear_migrations/management/commands/makemigrations.py
+++ b/src/django_linear_migrations/management/commands/makemigrations.py
@@ -1,60 +1,9 @@
-import sys
-
-from django.apps import apps
 from django.core.management.commands.makemigrations import Command as BaseCommand
 
 from django_linear_migrations.apps import MigrationDetails, first_party_app_configs
 
 
 class Command(BaseCommand):
-    def add_arguments(self, parser):
-        super().add_arguments(parser)
-        parser.add_argument(
-            "--create-max-migration-files",
-            action="store_true",
-            help=(
-                "Generate max_migration.txt files for first-party apps"
-                + " that don't have one, and exit."
-            ),
-        )
-
-    def handle(self, *app_labels, create_max_migration_files, **options):
-        if create_max_migration_files:
-            self._create_max_migration_files(set(app_labels))
-            return
-        super().handle(*app_labels, **options)
-
-    def _create_max_migration_files(self, app_labels):
-        # Copied check from base command
-        app_labels = set(app_labels)
-        has_bad_labels = False
-        for app_label in app_labels:
-            try:
-                apps.get_app_config(app_label)
-            except LookupError as err:
-                self.stderr.write(str(err))
-                has_bad_labels = True
-        if has_bad_labels:
-            sys.exit(2)
-
-        any_created = False
-        for app_config in first_party_app_configs():
-            if app_labels and app_config.label not in app_labels:
-                continue
-
-            migration_details = MigrationDetails(app_config.label)
-            max_migration_txt = migration_details.dir / "max_migration.txt"
-            if not max_migration_txt.exists():
-                max_migration_name = max(migration_details.names)
-                max_migration_txt.write_text(max_migration_name + "\n")
-                self.stdout.write(
-                    "Created max_migration.txt for {}".format(app_config.label)
-                )
-                any_created = True
-
-        if not any_created:
-            self.stdout.write("No max_migration.txt files need creating.")
-
     def write_migration_files(self, changes):
         super().write_migration_files(changes)
         if self.dry_run:

--- a/tests/test_create_max_migration_files.py
+++ b/tests/test_create_max_migration_files.py
@@ -1,0 +1,84 @@
+import sys
+import time
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+from django.test import TestCase, override_settings
+
+
+class MakeMigrationsTests(TestCase):
+    @pytest.fixture(autouse=True)
+    def tmp_path_fixture(self, tmp_path):
+        migrations_module_name = "migrations" + str(time.time()).replace(".", "")
+        self.migrations_dir = tmp_path / migrations_module_name
+        self.migrations_dir.mkdir()
+        sys.path.insert(0, str(tmp_path))
+        try:
+            with override_settings(
+                MIGRATION_MODULES={"testapp": migrations_module_name}
+            ):
+                yield
+        finally:
+            sys.path.pop(0)
+
+    def call_command(self, *args, **kwargs):
+        out = StringIO()
+        err = StringIO()
+        returncode = 0
+        try:
+            call_command(
+                "create-max-migration-files", *args, stdout=out, stderr=err, **kwargs
+            )
+        except SystemExit as exc:
+            returncode = exc.code
+        return out.getvalue(), err.getvalue(), returncode
+
+    def test_success(self):
+        (self.migrations_dir / "__init__.py").touch()
+        (self.migrations_dir / "0001_initial.py").touch()
+
+        out, err, returncode = self.call_command()
+
+        assert out == "Created max_migration.txt for testapp\n"
+        assert err == ""
+        assert returncode == 0
+        max_migration_txt = self.migrations_dir / "max_migration.txt"
+        assert max_migration_txt.read_text() == "0001_initial\n"
+
+    def test_success_already_exists(self):
+        (self.migrations_dir / "__init__.py").touch()
+        (self.migrations_dir / "0001_initial.py").touch()
+        (self.migrations_dir / "max_migration.txt").write_text("0001_initial\n")
+
+        out, err, returncode = self.call_command()
+
+        assert out == "No max_migration.txt files need creating.\n"
+        assert err == ""
+        assert returncode == 0
+
+    def test_success_specific_app_label(self):
+        (self.migrations_dir / "__init__.py").touch()
+        (self.migrations_dir / "0001_initial.py").touch()
+
+        out, err, returncode = self.call_command("testapp")
+
+        assert out == "Created max_migration.txt for testapp\n"
+        assert err == ""
+        assert returncode == 0
+        max_migration_txt = self.migrations_dir / "max_migration.txt"
+        assert max_migration_txt.read_text() == "0001_initial\n"
+
+    def test_error_specific_bad_app_label(self):
+        out, err, returncode = self.call_command("badapp")
+
+        assert out == ""
+        assert err == "No installed app with label 'badapp'.\n"
+        assert returncode == 2
+
+    def test_success_ignored_app_label(self):
+        out, err, returncode = self.call_command("django_linear_migrations")
+
+        assert out == "No max_migration.txt files need creating.\n"
+        assert err == ""
+        assert returncode == 0

--- a/tests/test_makemigrations.py
+++ b/tests/test_makemigrations.py
@@ -36,61 +36,6 @@ class MakeMigrationsTests(TestCase):
             returncode = exc.code
         return out.getvalue(), err.getvalue(), returncode
 
-    def test_create_max_migrations(self):
-        (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").touch()
-
-        out, err, returncode = self.call_command("--create-max-migration-files")
-
-        assert out == "Created max_migration.txt for testapp\n"
-        assert err == ""
-        assert returncode == 0
-        max_migration_txt = self.migrations_dir / "max_migration.txt"
-        assert max_migration_txt.read_text() == "0001_initial\n"
-
-    def test_create_max_migrations_exists(self):
-        (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").touch()
-        (self.migrations_dir / "max_migration.txt").write_text("0001_initial\n")
-
-        out, err, returncode = self.call_command("--create-max-migration-files")
-
-        assert out == "No max_migration.txt files need creating.\n"
-        assert err == ""
-        assert returncode == 0
-
-    def test_create_max_migrations_specific_app_label(self):
-        (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").touch()
-
-        out, err, returncode = self.call_command(
-            "--create-max-migration-files", "testapp"
-        )
-
-        assert out == "Created max_migration.txt for testapp\n"
-        assert err == ""
-        assert returncode == 0
-        max_migration_txt = self.migrations_dir / "max_migration.txt"
-        assert max_migration_txt.read_text() == "0001_initial\n"
-
-    def test_create_max_migrations_specific_bad_app_label(self):
-        out, err, returncode = self.call_command(
-            "--create-max-migration-files", "badapp"
-        )
-
-        assert out == ""
-        assert err == "No installed app with label 'badapp'.\n"
-        assert returncode == 2
-
-    def test_create_max_migrations_ignored_app_label(self):
-        out, err, returncode = self.call_command(
-            "--create-max-migration-files", "django_linear_migrations"
-        )
-
-        assert out == "No max_migration.txt files need creating.\n"
-        assert err == ""
-        assert returncode == 0
-
     def test_dry_run(self):
         out, err, returncode = self.call_command("--dry-run")
 


### PR DESCRIPTION
…es command

Fixes #11. It's not possible for the creation to exist in `makemigrations` since that runs system checks, including django-linear-migrations’ check that the files exist. Not detected in initial version since tests use `call_command` which skips checks.