### PR TITLE
Fix dlm_E001_hint: use the new command name

### DIFF
--- a/src/django_linear_migrations/apps.py
+++ b/src/django_linear_migrations/apps.py
@@ -73,7 +73,7 @@ class MigrationDetails:
 dlm_E001_msg = "{app_label}'s max_migration.txt does not exist."
 dlm_E001_hint = (
     "If you just installed django-linear-migrations, run 'python manage.py"
-    + " makemigrations --create-max-migrations'. Otherwise, check how it"
+    + " create-max-migration-files'. Otherwise, check how it"
     + " has gone missing."
 )
 


### PR DESCRIPTION
The hint was still referencing the old method of creating the max migration files.
Use the correct one.