### PR TITLE
Don't error out if migrations module has no migrations

### DIFF
--- a/src/django_linear_migrations/apps.py
+++ b/src/django_linear_migrations/apps.py
@@ -55,6 +55,7 @@ class MigrationDetails:
     def has_migrations(self):
         return (
             self.migrations_module is not None
+            and self.names
             and not is_namespace_module(self.migrations_module)
             # Django ignores non-package migrations modules
             and hasattr(self.migrations_module, "__path__")


### PR DESCRIPTION
handles `dlm.E001` if the django app has no migrations but still has an empty migrations folder module.