### PR TITLE
Add an escape hatch for automatic first-party app detection

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,9 @@
 History
 =======
 
+* Add the ability to define the list of first-party apps, for cases where the
+  automatic detection does not work.
+
 1.3.0 (2020-12-17)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -69,14 +69,42 @@ If your project has a custom ``makemigrations`` command, ensure the app containi
     class Command(BaseCommand):
         ...
 
-Third, run this one-off command for installation:
+Third, check the automatic detection of first-party apps.
+Run this command:
+
+.. code-block:: sh
+
+    python manage.py create-max-migration-files --dry-run
+
+This command is for creating ``max_migration.txt`` files (more on which later) - in dry run mode it lists the apps it would make such files for.
+It tries to automatically detect which apps are first-party, i.e. belong to your project.
+The automatic detection checks the path of app’s code to see if is within a virtualenv, but this detection can sometimes fail, for example on editable packages installed with ``-e``.
+If you see any apps listed that *aren’t* part of your project, define the list of first-party apps’ labels in a ``FIRST_PARTY_APPS`` setting that you combine into ``INSTALLED_APPS``:
+
+.. code-block:: python
+
+    FIRST_PARTY_APPS = [
+
+    ]
+
+    INSTALLED_APPS = FIRST_PARTY_APPS + [
+        "django_linear_migrations",
+        ...
+    ]
+
+(Note: Django recommends you always list first-party apps first in your project so they can override things in third-party and contrib apps.)
+
+Fourth, create the ``max_migration.txt`` files for your first-party apps:
 
 .. code-block:: sh
 
     python manage.py create-max-migration-files
 
-This creates a new ``max_migration.txt`` file in each of your first-party apps’ ``migrations`` directories and exits.
-More on those files below...
+In the future, when you add a new app to your project, you’ll need to add it to ``FIRST_PARTY_APPS`` (if defined) and rerun this command for the new app’s label:
+
+.. code-block:: sh
+
+    python manage.py create-max-migration-files my_new_app
 
 Usage
 =====

--- a/src/django_linear_migrations/apps.py
+++ b/src/django_linear_migrations/apps.py
@@ -3,6 +3,7 @@ from importlib import import_module, reload
 from pathlib import Path
 
 from django.apps import AppConfig, apps
+from django.conf import settings
 from django.core.checks import Error, Tags, register
 from django.db.migrations.loader import MigrationLoader
 from django.utils.functional import cached_property
@@ -19,6 +20,9 @@ class DjangoLinearMigrationsAppConfig(AppConfig):
 
 
 def is_first_party_app_config(app_config):
+    if settings.is_overridden("FIRST_PARTY_APPS"):
+        return app_config.label in settings.FIRST_PARTY_APPS
+
     # Check if it seems to be installed in a virtualenv
     path = Path(app_config.path)
     return "site-packages" not in path.parts and "dist-packages" not in path.parts

--- a/src/django_linear_migrations/management/commands/create-max-migration-files.py
+++ b/src/django_linear_migrations/management/commands/create-max-migration-files.py
@@ -23,8 +23,14 @@ class Command(BaseCommand):
             nargs="*",
             help="Specify the app label(s) to create max migration files for.",
         )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            default=False,
+            help="Actually create the files.",
+        )
 
-    def handle(self, *app_labels, **options):
+    def handle(self, *app_labels, dry_run, **options):
         # Copied check from makemigrations
         app_labels = set(app_labels)
         has_bad_labels = False
@@ -48,11 +54,18 @@ class Command(BaseCommand):
 
             max_migration_txt = migration_details.dir / "max_migration.txt"
             if not max_migration_txt.exists():
-                max_migration_name = max(migration_details.names)
-                max_migration_txt.write_text(max_migration_name + "\n")
-                self.stdout.write(
-                    "Created max_migration.txt for {}".format(app_config.label)
-                )
+                if not dry_run:
+                    max_migration_name = max(migration_details.names)
+                    max_migration_txt.write_text(max_migration_name + "\n")
+                    self.stdout.write(
+                        "Created max_migration.txt for {}.".format(app_config.label)
+                    )
+                else:
+                    self.stdout.write(
+                        "Would create max_migration.txt for {}.".format(
+                            app_config.label
+                        )
+                    )
                 any_created = True
 
         if not any_created:

--- a/tests/test_makemigrations.py
+++ b/tests/test_makemigrations.py
@@ -2,13 +2,10 @@ import sys
 import time
 from io import StringIO
 from textwrap import dedent
-from unittest import mock
 
 import pytest
 from django.core.management import call_command
 from django.test import TestCase, override_settings
-
-from django_linear_migrations.management.commands import makemigrations
 
 
 class MakeMigrationsTests(TestCase):
@@ -80,11 +77,9 @@ class MakeMigrationsTests(TestCase):
         max_migration_txt = self.migrations_dir / "max_migration.txt"
         assert max_migration_txt.read_text() == "0002_create_book\n"
 
+    @override_settings(FIRST_PARTY_APPS=[])
     def test_skips_creating_max_migration_txt_for_non_first_party_app(self):
-        with mock.patch.object(
-            makemigrations, "first_party_app_configs", return_value=[]
-        ):
-            out, err, returncode = self.call_command("testapp")
+        out, err, returncode = self.call_command("testapp")
 
         assert returncode == 0
         max_migration_txt = self.migrations_dir / "max_migration.txt"


### PR DESCRIPTION
Alternative fix as suggested in the discussion of #28.