### PR TITLE
Improve detection of first party apps.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,11 @@ History
   run outside of the tox setup in the repository. Repackagers can use GitHub's
   tarballs per tag.
 
+1.5.2 (unreleased)
+------------------
+
+* Improve detection of first party apps.
+
 1.5.1 (2021-03-09)
 ------------------
 

--- a/src/django_linear_migrations/apps.py
+++ b/src/django_linear_migrations/apps.py
@@ -21,7 +21,7 @@ class DjangoLinearMigrationsAppConfig(AppConfig):
 
 def is_first_party_app_config(app_config):
     if settings.is_overridden("FIRST_PARTY_APPS"):
-        return app_config.label in settings.FIRST_PARTY_APPS
+        return app_config.name in settings.FIRST_PARTY_APPS
 
     # Check if it seems to be installed in a virtualenv
     path = Path(app_config.path)


### PR DESCRIPTION
Django apps are sometimes referenced with their dotted path in `settings.FIRST_PARTY_APPS`, e.g. `myproject.myapp`. But the label of the app config is the right most part of the path, e.g. `myapp` which is not in `settings.FIRST_PARTY_APPS` and thus the app will not be considered a first party app.

We can improve this by looking at the name of the app config, which should normally correspond to the dotted path of the app.

A similar problem arises if `settings.FIRST_PARTY_APPS` contains the dotted path to the app's app config class, e.g. `myproject.myapp.apps.MyAppConfigSubclass`. But that can be worked around by putting `default_app_config` into the apps `__init__.py`, so we are not addressing that right now.