### PR TITLE
Use MigrationLoader to order migrations

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,9 @@
 History
 =======
 
+* Use Django’s ``MigrationLoader`` to find the latest migrations.
+  This also means django-linear-migrations operations detect migration conflicts.
+
 2.5.1 (2022-07-20)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -122,6 +122,7 @@ These are:
 * ``dlm.E002``: ``<app_label>``'s max_migration.txt contains multiple lines.
 * ``dlm.E003``: ``<app_label>``'s max_migration.txt points to non-existent migration '``<bad_migration_name>``'.
 * ``dlm.E004``: ``<app_label>``'s max_migration.txt contains '``<max_migration_name>``', but the latest migration is '``<real_max_migration_name>``'.
+* ``dlm.E005``: Conflicting migrations detected; multiple leaf nodes in the migration graph: ``<conflicting_migrations>``
 
 ``create_max_migration_files`` Command
 --------------------------------------

--- a/src/django_linear_migrations/apps.py
+++ b/src/django_linear_migrations/apps.py
@@ -154,7 +154,9 @@ def check_max_migration_files(
                     "Conflicting migrations detected;"
                     + f" multiple leaf nodes in the migration graph: {conflict_msg}."
                 ),
-                hint="Run 'python manage.py makemigrations --merge'",
+                hint=(
+                    "Fix the conflict, e.g. with './manage.py makemigrations --merge'."
+                ),
             )
         )
         return errors

--- a/src/django_linear_migrations/apps.py
+++ b/src/django_linear_migrations/apps.py
@@ -64,7 +64,11 @@ def get_graph_plan(
 ) -> list[tuple[str, str]]:
     nodes = loader.graph.leaf_nodes()
     if app_labels:
-        nodes = [key for key in loader.graph.leaf_nodes() if key[0] in app_labels]
+        nodes = [
+            (app_label, name)
+            for app_label, name in loader.graph.leaf_nodes()
+            if app_label in app_labels
+        ]
     plan: list[tuple[str, str]] = loader.graph._generate_plan(nodes, at_end=True)
     return plan
 
@@ -216,7 +220,9 @@ def check_max_migration_files(
             )
             continue
 
-        real_max_migration_name = [k[1] for k in graph_plan if k[0] == app_label][-1]
+        real_max_migration_name = [
+            name for gp_app_label, name in graph_plan if gp_app_label == app_label
+        ][-1]
         if max_migration_name != real_max_migration_name:
             errors.append(
                 Error(

--- a/src/django_linear_migrations/apps.py
+++ b/src/django_linear_migrations/apps.py
@@ -16,8 +16,6 @@ from django.core.checks import Error
 from django.core.checks import register
 from django.core.checks import Tags
 from django.core.signals import setting_changed
-from django.db import connections
-from django.db import DEFAULT_DB_ALIAS
 from django.db.migrations.loader import MigrationLoader
 from django.dispatch import receiver
 from django.utils.functional import cached_property
@@ -134,9 +132,7 @@ def check_max_migration_files(
     else:
         app_config_set = set()
 
-    migration_loader = MigrationLoader(
-        connections[DEFAULT_DB_ALIAS], ignore_no_migrations=True
-    )
+    migration_loader = MigrationLoader(None, ignore_no_migrations=True)
     app_labels = [a.label for a in first_party_app_configs()]
     conflicts = {
         app_label: names

--- a/src/django_linear_migrations/apps.py
+++ b/src/django_linear_migrations/apps.py
@@ -9,6 +9,8 @@ from types import ModuleType
 from typing import cast
 from typing import Generator
 from typing import Iterable
+from typing import List
+from typing import Tuple
 
 from django.apps import AppConfig
 from django.apps import apps
@@ -69,7 +71,7 @@ def get_graph_plan(
     if app_names:
         nodes = [key for key in loader.graph.leaf_nodes() if key[0] in app_names]
     plan = loader.graph._generate_plan(nodes, at_end=True)
-    return cast(list[tuple[str, str]], plan)
+    return cast(List[Tuple[str, str]], plan)
 
 
 class MigrationDetails:

--- a/src/django_linear_migrations/apps.py
+++ b/src/django_linear_migrations/apps.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from types import ModuleType
 from typing import Generator
 from typing import Iterable
+from typing import cast
 
 from django.apps import AppConfig
 from django.apps import apps
@@ -116,12 +117,8 @@ class MigrationDetails:
     def plan(self) -> list[tuple[str, str]]:
         loader = MigrationLoader(connections[DEFAULT_DB_ALIAS])
         nodes = [key for key in loader.graph.leaf_nodes() if key[0] in self.app_label]
-        plan = []
-        for node in nodes:
-            for migration in loader.graph.forwards_plan(node):
-                if migration not in plan:
-                    plan.append(migration)
-        return plan
+        plan = loader.graph._generate_plan(nodes, at_end=True)
+        return cast(list[tuple[str, str]], plan)
 
 
 def check_max_migration_files(

--- a/src/django_linear_migrations/apps.py
+++ b/src/django_linear_migrations/apps.py
@@ -58,21 +58,6 @@ def first_party_app_configs() -> Generator[AppConfig, None, None]:
             yield app_config
 
 
-def get_graph_plan(
-    loader: MigrationLoader,
-    app_labels: Iterable[str] | None = None,
-) -> list[tuple[str, str]]:
-    nodes = loader.graph.leaf_nodes()
-    if app_labels:
-        nodes = [
-            (app_label, name)
-            for app_label, name in loader.graph.leaf_nodes()
-            if app_label in app_labels
-        ]
-    plan: list[tuple[str, str]] = loader.graph._generate_plan(nodes, at_end=True)
-    return plan
-
-
 class MigrationDetails:
     migrations_module_name: str | None
     migrations_module: ModuleType | None
@@ -125,6 +110,20 @@ class MigrationDetails:
             for _, name, is_pkg in pkgutil.iter_modules(path)
             if not is_pkg and name[0] not in "_~"
         }
+
+
+def get_graph_plan(
+    loader: MigrationLoader, app_labels: Iterable[str] | None = None
+) -> list[tuple[str, str]]:
+    nodes = loader.graph.leaf_nodes()
+    if app_labels:
+        nodes = [
+            (app_label, name)
+            for app_label, name in loader.graph.leaf_nodes()
+            if app_label in app_labels
+        ]
+    plan: list[tuple[str, str]] = loader.graph._generate_plan(nodes, at_end=True)
+    return plan
 
 
 def check_max_migration_files(

--- a/src/django_linear_migrations/apps.py
+++ b/src/django_linear_migrations/apps.py
@@ -62,11 +62,11 @@ def first_party_app_configs() -> Generator[AppConfig, None, None]:
 
 def get_graph_plan(
     loader: MigrationLoader,
-    app_names: Iterable[str] | None = None,
+    app_labels: Iterable[str] | None = None,
 ) -> list[tuple[str, str]]:
     nodes = loader.graph.leaf_nodes()
-    if app_names:
-        nodes = [key for key in loader.graph.leaf_nodes() if key[0] in app_names]
+    if app_labels:
+        nodes = [key for key in loader.graph.leaf_nodes() if key[0] in app_labels]
     plan: list[tuple[str, str]] = loader.graph._generate_plan(nodes, at_end=True)
     return plan
 
@@ -137,13 +137,13 @@ def check_max_migration_files(
     migration_loader = MigrationLoader(
         connections[DEFAULT_DB_ALIAS], ignore_no_migrations=True
     )
-    app_names = [a.label for a in first_party_app_configs()]
+    app_labels = [a.label for a in first_party_app_configs()]
     conflicts = migration_loader.detect_conflicts()
-    if app_names:
+    if app_labels:
         conflicts = {
             app_label: conflict
             for app_label, conflict in conflicts.items()
-            if app_label in app_names
+            if app_label in app_labels
         }
     if conflicts:
         conflict_msg = "; ".join(
@@ -161,7 +161,7 @@ def check_max_migration_files(
         )
         return errors
 
-    graph_plan = get_graph_plan(loader=migration_loader, app_names=app_names)
+    graph_plan = get_graph_plan(loader=migration_loader, app_labels=app_labels)
     for app_config in first_party_app_configs():
         # When only checking certain apps, skip the others
         if app_configs is not None and app_config not in app_config_set:

--- a/src/django_linear_migrations/apps.py
+++ b/src/django_linear_migrations/apps.py
@@ -6,11 +6,8 @@ from importlib import import_module
 from importlib import reload
 from pathlib import Path
 from types import ModuleType
-from typing import cast
 from typing import Generator
 from typing import Iterable
-from typing import List
-from typing import Tuple
 
 from django.apps import AppConfig
 from django.apps import apps
@@ -70,8 +67,8 @@ def get_graph_plan(
     nodes = loader.graph.leaf_nodes()
     if app_names:
         nodes = [key for key in loader.graph.leaf_nodes() if key[0] in app_names]
-    plan = loader.graph._generate_plan(nodes, at_end=True)
-    return cast(List[Tuple[str, str]], plan)
+    plan: list[tuple[str, str]] = loader.graph._generate_plan(nodes, at_end=True)
+    return plan
 
 
 class MigrationDetails:

--- a/src/django_linear_migrations/apps.py
+++ b/src/django_linear_migrations/apps.py
@@ -139,20 +139,21 @@ def check_max_migration_files(
     )
     app_labels = [a.label for a in first_party_app_configs()]
     conflicts = {
-        app_label: conflict
-        for app_label, conflict in migration_loader.detect_conflicts().items()
+        app_label: names
+        for app_label, names in migration_loader.detect_conflicts().items()
         if app_label in app_labels
     }
     if conflicts:
-        conflict_msg = "; ".join(
-            f"{', '.join(names)} in {app}" for app, names in conflicts.items()
+        conflict_msg = "".join(
+            f"\n* {app_label}: {', '.join(sorted(names))}"
+            for app_label, names in conflicts.items()
         )
         errors.append(
             Error(
                 id="dlm.E005",
                 msg=(
-                    "Conflicting migrations detected;"
-                    + f" multiple leaf nodes in the migration graph: {conflict_msg}."
+                    "Conflicting migrations detected - multiple leaf nodes "
+                    + f"detected for these apps:{conflict_msg}"
                 ),
                 hint=(
                     "Fix the conflict, e.g. with './manage.py makemigrations --merge'."

--- a/src/django_linear_migrations/apps.py
+++ b/src/django_linear_migrations/apps.py
@@ -138,13 +138,11 @@ def check_max_migration_files(
         connections[DEFAULT_DB_ALIAS], ignore_no_migrations=True
     )
     app_labels = [a.label for a in first_party_app_configs()]
-    conflicts = migration_loader.detect_conflicts()
-    if app_labels:
-        conflicts = {
-            app_label: conflict
-            for app_label, conflict in conflicts.items()
-            if app_label in app_labels
-        }
+    conflicts = {
+        app_label: conflict
+        for app_label, conflict in migration_loader.detect_conflicts().items()
+        if app_label in app_labels
+    }
     if conflicts:
         conflict_msg = "; ".join(
             f"{', '.join(names)} in {app}" for app, names in conflicts.items()

--- a/src/django_linear_migrations/apps.py
+++ b/src/django_linear_migrations/apps.py
@@ -149,15 +149,15 @@ def check_max_migration_files(
             if app_label in app_names
         }
     if conflicts:
-        name_str = "; ".join(
+        conflict_msg = "; ".join(
             f"{', '.join(names)} in {app}" for app, names in conflicts.items()
         )
         errors.append(
             Error(
-                id="dlm.E000",
+                id="dlm.E005",
                 msg=(
                     "Conflicting migrations detected;"
-                    + f" multiple leaf nodes in the migration graph: {name_str}."
+                    + f" multiple leaf nodes in the migration graph: {conflict_msg}."
                 ),
                 hint="Run 'python manage.py makemigrations --merge'",
             )

--- a/src/django_linear_migrations/management/commands/create_max_migration_files.py
+++ b/src/django_linear_migrations/management/commands/create_max_migration_files.py
@@ -6,6 +6,9 @@ from typing import Any
 
 from django.apps import apps
 from django.core.management.commands.makemigrations import Command as BaseCommand
+from django.db import connections
+from django.db import DEFAULT_DB_ALIAS
+from django.db.migrations.loader import MigrationLoader
 
 from django_linear_migrations.apps import first_party_app_configs
 from django_linear_migrations.apps import get_graph_plan
@@ -58,7 +61,10 @@ class Command(BaseCommand):
             sys.exit(2)
 
         any_created = False
-        graph_plan = get_graph_plan(app_names=labels)
+        migration_loader = MigrationLoader(
+            connections[DEFAULT_DB_ALIAS], ignore_no_migrations=True
+        )
+        graph_plan = get_graph_plan(loader=migration_loader, app_names=labels)
         for app_config in first_party_app_configs():
             if labels and app_config.label not in labels:
                 continue

--- a/src/django_linear_migrations/management/commands/create_max_migration_files.py
+++ b/src/django_linear_migrations/management/commands/create_max_migration_files.py
@@ -8,6 +8,7 @@ from django.apps import apps
 from django.core.management.commands.makemigrations import Command as BaseCommand
 
 from django_linear_migrations.apps import first_party_app_configs
+from django_linear_migrations.apps import get_graph_plan
 from django_linear_migrations.apps import MigrationDetails
 
 
@@ -57,6 +58,7 @@ class Command(BaseCommand):
             sys.exit(2)
 
         any_created = False
+        graph_plan = get_graph_plan(app_names=labels)
         for app_config in first_party_app_configs():
             if labels and app_config.label not in labels:
                 continue
@@ -68,7 +70,9 @@ class Command(BaseCommand):
             max_migration_txt = migration_details.dir / "max_migration.txt"
             if recreate or not max_migration_txt.exists():
                 if not dry_run:
-                    _, max_migration_name = migration_details.plan[-1]
+                    max_migration_name = [
+                        k[1] for k in graph_plan if k[0] == app_config.label
+                    ][-1]
                     max_migration_txt.write_text(max_migration_name + "\n")
                     self.stdout.write(
                         f"Created max_migration.txt for {app_config.label}."

--- a/src/django_linear_migrations/management/commands/create_max_migration_files.py
+++ b/src/django_linear_migrations/management/commands/create_max_migration_files.py
@@ -64,7 +64,7 @@ class Command(BaseCommand):
         migration_loader = MigrationLoader(
             connections[DEFAULT_DB_ALIAS], ignore_no_migrations=True
         )
-        graph_plan = get_graph_plan(loader=migration_loader, app_names=labels)
+        graph_plan = get_graph_plan(loader=migration_loader, app_labels=labels)
         for app_config in first_party_app_configs():
             if labels and app_config.label not in labels:
                 continue

--- a/src/django_linear_migrations/management/commands/create_max_migration_files.py
+++ b/src/django_linear_migrations/management/commands/create_max_migration_files.py
@@ -6,8 +6,6 @@ from typing import Any
 
 from django.apps import apps
 from django.core.management.commands.makemigrations import Command as BaseCommand
-from django.db import connections
-from django.db import DEFAULT_DB_ALIAS
 from django.db.migrations.loader import MigrationLoader
 
 from django_linear_migrations.apps import first_party_app_configs
@@ -61,9 +59,7 @@ class Command(BaseCommand):
             sys.exit(2)
 
         any_created = False
-        migration_loader = MigrationLoader(
-            connections[DEFAULT_DB_ALIAS], ignore_no_migrations=True
-        )
+        migration_loader = MigrationLoader(None, ignore_no_migrations=True)
         graph_plan = get_graph_plan(loader=migration_loader, app_labels=labels)
         for app_config in first_party_app_configs():
             if labels and app_config.label not in labels:

--- a/src/django_linear_migrations/management/commands/create_max_migration_files.py
+++ b/src/django_linear_migrations/management/commands/create_max_migration_files.py
@@ -68,7 +68,7 @@ class Command(BaseCommand):
             max_migration_txt = migration_details.dir / "max_migration.txt"
             if recreate or not max_migration_txt.exists():
                 if not dry_run:
-                    max_migration_name = max(migration_details.names)
+                    _, max_migration_name = migration_details.plan[-1]
                     max_migration_txt.write_text(max_migration_name + "\n")
                     self.stdout.write(
                         f"Created max_migration.txt for {app_config.label}."

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -5,7 +5,6 @@ import time
 from textwrap import dedent
 
 import pytest
-from django.core.management import CommandError
 from django.test import override_settings
 from django.test import TestCase
 
@@ -113,7 +112,7 @@ class CheckMaxMigrationFilesTests(TestCase):
             + " latest migration is '0002_updates'."
         )
 
-    def test_dlm_E005(self):
+    def test_dlm_E000(self):
         (self.migrations_dir / "__init__.py").touch()
         (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
         (self.migrations_dir / "custom_name.py").write_text(
@@ -136,15 +135,14 @@ class CheckMaxMigrationFilesTests(TestCase):
         )
         (self.migrations_dir / "max_migration.txt").write_text("0002_updates\n")
 
-        with pytest.raises(CommandError):
-            result = check_max_migration_files()
-            assert len(result) == 1
-            assert result[0].id == "dlm.E005"
-            assert (
-                result[0].msg
-                == "Conflicting migrations detected; multiple leaf nodes"
-                + " in the migration graph: 0002_updates, custom_name in testapp."
-            )
+        result = check_max_migration_files()
+        assert len(result) == 1
+        assert result[0].id == "dlm.E000"
+        assert (
+            result[0].msg
+            == "Conflicting migrations detected; multiple leaf nodes"
+            + " in the migration graph: 0002_updates, custom_name in testapp."
+        )
 
     def test_okay(self):
         (self.migrations_dir / "__init__.py").touch()

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -138,10 +138,10 @@ class CheckMaxMigrationFilesTests(TestCase):
         result = check_max_migration_files()
         assert len(result) == 1
         assert result[0].id == "dlm.E005"
-        assert (
-            result[0].msg
-            == "Conflicting migrations detected; multiple leaf nodes"
-            + " in the migration graph: 0002_updates, custom_name in testapp."
+        assert result[0].msg == (
+            "Conflicting migrations detected - multiple leaf nodes "
+            + "detected for these apps:\n"
+            + "* testapp: 0002_updates, custom_name"
         )
 
     def test_okay(self):

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -112,7 +112,7 @@ class CheckMaxMigrationFilesTests(TestCase):
             + " latest migration is '0002_updates'."
         )
 
-    def test_dlm_E000(self):
+    def test_dlm_E005(self):
         (self.migrations_dir / "__init__.py").touch()
         (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
         (self.migrations_dir / "custom_name.py").write_text(
@@ -137,7 +137,7 @@ class CheckMaxMigrationFilesTests(TestCase):
 
         result = check_max_migration_files()
         assert len(result) == 1
-        assert result[0].id == "dlm.E000"
+        assert result[0].id == "dlm.E005"
         assert (
             result[0].msg
             == "Conflicting migrations detected; multiple leaf nodes"

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -56,7 +56,7 @@ class CheckMaxMigrationFilesTests(TestCase):
 
     def test_dlm_E001(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
 
         result = check_max_migration_files()
 
@@ -66,7 +66,7 @@ class CheckMaxMigrationFilesTests(TestCase):
 
     def test_dlm_E002(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
         (self.migrations_dir / "max_migration.txt").write_text("line1\nline2\n")
 
         result = check_max_migration_files()
@@ -77,7 +77,7 @@ class CheckMaxMigrationFilesTests(TestCase):
 
     def test_dlm_E003(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
         (self.migrations_dir / "max_migration.txt").write_text("0001_start\n")
 
         result = check_max_migration_files()
@@ -91,7 +91,7 @@ class CheckMaxMigrationFilesTests(TestCase):
 
     def test_dlm_E004(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
         (self.migrations_dir / "0002_updates.py").write_text(
             dedent(
                 """
@@ -114,7 +114,7 @@ class CheckMaxMigrationFilesTests(TestCase):
 
     def test_dlm_E005(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
         (self.migrations_dir / "custom_name.py").write_text(
             dedent(
                 """
@@ -146,7 +146,7 @@ class CheckMaxMigrationFilesTests(TestCase):
 
     def test_okay(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
         (self.migrations_dir / "0002_updates.py").write_text(
             dedent(
                 """

--- a/tests/test_create_max_migration_files.py
+++ b/tests/test_create_max_migration_files.py
@@ -80,7 +80,7 @@ class CreateMaxMigrationFilesTests(TestCase):
     @override_settings(FIRST_PARTY_APPS=[])
     def test_success_setting_not_first_party(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
 
         out, err, returncode = self.call_command()
 
@@ -90,7 +90,7 @@ class CreateMaxMigrationFilesTests(TestCase):
 
     def test_success_dry_run(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
 
         out, err, returncode = self.call_command("--dry-run")
 
@@ -102,7 +102,7 @@ class CreateMaxMigrationFilesTests(TestCase):
 
     def test_success(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
 
         out, err, returncode = self.call_command()
 
@@ -114,7 +114,7 @@ class CreateMaxMigrationFilesTests(TestCase):
 
     def test_success_already_exists(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
         (self.migrations_dir / "max_migration.txt").write_text("0001_initial\n")
 
         out, err, returncode = self.call_command()
@@ -125,7 +125,7 @@ class CreateMaxMigrationFilesTests(TestCase):
 
     def test_success_recreate(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
         (self.migrations_dir / "max_migration.txt").write_text("0001_initial\n")
 
         out, err, returncode = self.call_command("--recreate")
@@ -136,7 +136,7 @@ class CreateMaxMigrationFilesTests(TestCase):
 
     def test_success_recreate_dry_run(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
         (self.migrations_dir / "max_migration.txt").write_text("0001_initial\n")
 
         out, err, returncode = self.call_command("--recreate", "--dry-run")
@@ -147,7 +147,7 @@ class CreateMaxMigrationFilesTests(TestCase):
 
     def test_success_specific_app_label(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
 
         out, err, returncode = self.call_command("testapp")
 
@@ -175,7 +175,7 @@ class CreateMaxMigrationFilesTests(TestCase):
 
     def test_success_custom_migration_name(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
         (self.migrations_dir / "custom_name.py").write_text(
             dedent(
                 """

--- a/tests/test_create_max_migration_files.py
+++ b/tests/test_create_max_migration_files.py
@@ -10,6 +10,8 @@ from django.core.management import call_command
 from django.test import override_settings
 from django.test import TestCase
 
+from tests.utils import empty_migration
+
 
 class CreateMaxMigrationFilesTests(TestCase):
     @pytest.fixture(autouse=True)
@@ -78,7 +80,7 @@ class CreateMaxMigrationFilesTests(TestCase):
     @override_settings(FIRST_PARTY_APPS=[])
     def test_success_setting_not_first_party(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").touch()
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
 
         out, err, returncode = self.call_command()
 
@@ -88,7 +90,7 @@ class CreateMaxMigrationFilesTests(TestCase):
 
     def test_success_dry_run(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").touch()
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
 
         out, err, returncode = self.call_command("--dry-run")
 
@@ -100,15 +102,7 @@ class CreateMaxMigrationFilesTests(TestCase):
 
     def test_success(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(
-            dedent(
-                """
-                from django.db import migrations
-                class Migration(migrations.Migration):
-                    pass
-                """
-            )
-        )
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
 
         out, err, returncode = self.call_command()
 
@@ -120,7 +114,7 @@ class CreateMaxMigrationFilesTests(TestCase):
 
     def test_success_already_exists(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").touch()
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
         (self.migrations_dir / "max_migration.txt").write_text("0001_initial\n")
 
         out, err, returncode = self.call_command()
@@ -131,15 +125,7 @@ class CreateMaxMigrationFilesTests(TestCase):
 
     def test_success_recreate(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(
-            dedent(
-                """
-                from django.db import migrations
-                class Migration(migrations.Migration):
-                    pass
-                """
-            )
-        )
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
         (self.migrations_dir / "max_migration.txt").write_text("0001_initial\n")
 
         out, err, returncode = self.call_command("--recreate")
@@ -150,7 +136,7 @@ class CreateMaxMigrationFilesTests(TestCase):
 
     def test_success_recreate_dry_run(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").touch()
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
         (self.migrations_dir / "max_migration.txt").write_text("0001_initial\n")
 
         out, err, returncode = self.call_command("--recreate", "--dry-run")
@@ -161,15 +147,7 @@ class CreateMaxMigrationFilesTests(TestCase):
 
     def test_success_specific_app_label(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(
-            dedent(
-                """
-                from django.db import migrations
-                class Migration(migrations.Migration):
-                    pass
-                """
-            )
-        )
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
 
         out, err, returncode = self.call_command("testapp")
 
@@ -197,15 +175,7 @@ class CreateMaxMigrationFilesTests(TestCase):
 
     def test_success_custom_migration_name(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(
-            dedent(
-                """
-                from django.db import migrations
-                class Migration(migrations.Migration):
-                    pass
-                """
-            )
-        )
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
         (self.migrations_dir / "custom_name.py").write_text(
             dedent(
                 """

--- a/tests/test_rebase_migration.py
+++ b/tests/test_rebase_migration.py
@@ -45,7 +45,7 @@ class RebaseMigrationsTests(TestCase):
 
     def test_error_for_no_max_migration_txt(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
 
         with pytest.raises(CommandError) as excinfo:
             self.call_command("testapp")
@@ -54,7 +54,7 @@ class RebaseMigrationsTests(TestCase):
 
     def test_error_for_no_migration_conflict(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
         (self.migrations_dir / "max_migration.txt").write_text("0001_initial\n")
 
         with pytest.raises(CommandError) as excinfo:
@@ -67,7 +67,7 @@ class RebaseMigrationsTests(TestCase):
 
     def test_error_for_non_existent_merged_migration(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
         (self.migrations_dir / "max_migration.txt").write_text(
             dedent(
                 """\
@@ -91,8 +91,8 @@ class RebaseMigrationsTests(TestCase):
 
     def test_error_for_non_existent_rebased_migration(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
-        (self.migrations_dir / "0002_author_nicknames.py").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
+        (self.migrations_dir / "0002_author_nicknames.py").write_text(empty_migration)
         (self.migrations_dir / "max_migration.txt").write_text(
             dedent(
                 """\
@@ -116,9 +116,9 @@ class RebaseMigrationsTests(TestCase):
 
     def test_error_for_non_existent_rebased_migration_file(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
-        (self.migrations_dir / "0002_author_nicknames.py").write_text(empty_migration())
-        (self.migrations_dir / "0002_longer_titles.pyc").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
+        (self.migrations_dir / "0002_author_nicknames.py").write_text(empty_migration)
+        (self.migrations_dir / "0002_longer_titles.pyc").write_text(empty_migration)
         (self.migrations_dir / "max_migration.txt").write_text(
             dedent(
                 """\
@@ -141,9 +141,9 @@ class RebaseMigrationsTests(TestCase):
 
     def test_error_for_applied_migration(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
-        (self.migrations_dir / "0002_author_nicknames.py").write_text(empty_migration())
-        (self.migrations_dir / "0002_longer_titles.py").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
+        (self.migrations_dir / "0002_author_nicknames.py").write_text(empty_migration)
+        (self.migrations_dir / "0002_longer_titles.py").write_text(empty_migration)
         (self.migrations_dir / "max_migration.txt").write_text(
             dedent(
                 """\
@@ -170,8 +170,8 @@ class RebaseMigrationsTests(TestCase):
 
     def test_error_for_missing_dependencies(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
-        (self.migrations_dir / "0002_author_nicknames.py").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
+        (self.migrations_dir / "0002_author_nicknames.py").write_text(empty_migration)
         (self.migrations_dir / "0002_longer_titles.py").write_text(
             dedent(
                 """\
@@ -203,8 +203,8 @@ class RebaseMigrationsTests(TestCase):
 
     def test_error_for_unparseable_dependencies(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
-        (self.migrations_dir / "0002_author_nicknames.py").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
+        (self.migrations_dir / "0002_author_nicknames.py").write_text(empty_migration)
         (self.migrations_dir / "0002_longer_titles.py").write_text(
             dedent(
                 """\
@@ -237,8 +237,8 @@ class RebaseMigrationsTests(TestCase):
 
     def test_error_for_no_dependencies(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
-        (self.migrations_dir / "0002_author_nicknames.py").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
+        (self.migrations_dir / "0002_author_nicknames.py").write_text(empty_migration)
         (self.migrations_dir / "0002_longer_titles.py").write_text(
             dedent(
                 """\
@@ -274,8 +274,8 @@ class RebaseMigrationsTests(TestCase):
 
     def test_error_for_double_dependencies(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
-        (self.migrations_dir / "0002_author_nicknames.py").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
+        (self.migrations_dir / "0002_author_nicknames.py").write_text(empty_migration)
         (self.migrations_dir / "0002_longer_titles.py").write_text(
             dedent(
                 """\
@@ -312,7 +312,7 @@ class RebaseMigrationsTests(TestCase):
 
     def test_success(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
         (self.migrations_dir / "0002_longer_titles.py").write_text(
             dedent(
                 """\
@@ -368,7 +368,7 @@ class RebaseMigrationsTests(TestCase):
 
     def test_success_swappable_dependency(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration)
         (self.migrations_dir / "0002_longer_titles.py").write_text(
             dedent(
                 """\

--- a/tests/test_rebase_migration.py
+++ b/tests/test_rebase_migration.py
@@ -15,6 +15,7 @@ from django.test import SimpleTestCase
 from django.test import TestCase
 
 from django_linear_migrations.management.commands import rebase_migration as module
+from tests.utils import empty_migration
 from tests.utils import run_command
 
 
@@ -44,7 +45,7 @@ class RebaseMigrationsTests(TestCase):
 
     def test_error_for_no_max_migration_txt(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").touch()
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
 
         with pytest.raises(CommandError) as excinfo:
             self.call_command("testapp")
@@ -53,7 +54,7 @@ class RebaseMigrationsTests(TestCase):
 
     def test_error_for_no_migration_conflict(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").touch()
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
         (self.migrations_dir / "max_migration.txt").write_text("0001_initial\n")
 
         with pytest.raises(CommandError) as excinfo:
@@ -66,7 +67,7 @@ class RebaseMigrationsTests(TestCase):
 
     def test_error_for_non_existent_merged_migration(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").touch()
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
         (self.migrations_dir / "max_migration.txt").write_text(
             dedent(
                 """\
@@ -90,8 +91,8 @@ class RebaseMigrationsTests(TestCase):
 
     def test_error_for_non_existent_rebased_migration(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").touch()
-        (self.migrations_dir / "0002_author_nicknames.py").touch()
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0002_author_nicknames.py").write_text(empty_migration())
         (self.migrations_dir / "max_migration.txt").write_text(
             dedent(
                 """\
@@ -115,9 +116,9 @@ class RebaseMigrationsTests(TestCase):
 
     def test_error_for_non_existent_rebased_migration_file(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").touch()
-        (self.migrations_dir / "0002_author_nicknames.py").touch()
-        (self.migrations_dir / "0002_longer_titles.pyc").touch()
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0002_author_nicknames.py").write_text(empty_migration())
+        (self.migrations_dir / "0002_longer_titles.pyc").write_text(empty_migration())
         (self.migrations_dir / "max_migration.txt").write_text(
             dedent(
                 """\
@@ -140,9 +141,9 @@ class RebaseMigrationsTests(TestCase):
 
     def test_error_for_applied_migration(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").touch()
-        (self.migrations_dir / "0002_author_nicknames.py").touch()
-        (self.migrations_dir / "0002_longer_titles.py").touch()
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0002_author_nicknames.py").write_text(empty_migration())
+        (self.migrations_dir / "0002_longer_titles.py").write_text(empty_migration())
         (self.migrations_dir / "max_migration.txt").write_text(
             dedent(
                 """\
@@ -169,8 +170,8 @@ class RebaseMigrationsTests(TestCase):
 
     def test_error_for_missing_dependencies(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").touch()
-        (self.migrations_dir / "0002_author_nicknames.py").touch()
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0002_author_nicknames.py").write_text(empty_migration())
         (self.migrations_dir / "0002_longer_titles.py").write_text(
             dedent(
                 """\
@@ -202,8 +203,8 @@ class RebaseMigrationsTests(TestCase):
 
     def test_error_for_unparseable_dependencies(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").touch()
-        (self.migrations_dir / "0002_author_nicknames.py").touch()
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0002_author_nicknames.py").write_text(empty_migration())
         (self.migrations_dir / "0002_longer_titles.py").write_text(
             dedent(
                 """\
@@ -236,8 +237,8 @@ class RebaseMigrationsTests(TestCase):
 
     def test_error_for_no_dependencies(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").touch()
-        (self.migrations_dir / "0002_author_nicknames.py").touch()
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0002_author_nicknames.py").write_text(empty_migration())
         (self.migrations_dir / "0002_longer_titles.py").write_text(
             dedent(
                 """\
@@ -273,8 +274,8 @@ class RebaseMigrationsTests(TestCase):
 
     def test_error_for_double_dependencies(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").touch()
-        (self.migrations_dir / "0002_author_nicknames.py").touch()
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
+        (self.migrations_dir / "0002_author_nicknames.py").write_text(empty_migration())
         (self.migrations_dir / "0002_longer_titles.py").write_text(
             dedent(
                 """\
@@ -311,7 +312,7 @@ class RebaseMigrationsTests(TestCase):
 
     def test_success(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").touch()
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
         (self.migrations_dir / "0002_longer_titles.py").write_text(
             dedent(
                 """\
@@ -367,7 +368,7 @@ class RebaseMigrationsTests(TestCase):
 
     def test_success_swappable_dependency(self):
         (self.migrations_dir / "__init__.py").touch()
-        (self.migrations_dir / "0001_initial.py").touch()
+        (self.migrations_dir / "0001_initial.py").write_text(empty_migration())
         (self.migrations_dir / "0002_longer_titles.py").write_text(
             dedent(
                 """\

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,11 +17,10 @@ def run_command(*args, **kwargs):
     return out.getvalue(), err.getvalue(), returncode
 
 
-def empty_migration() -> str:
-    return dedent(
-        """
-        from django.db import migrations
-        class Migration(migrations.Migration):
-            pass
-        """
-    )
+empty_migration = dedent(
+    """\
+    from django.db import migrations
+    class Migration(migrations.Migration):
+        pass
+    """
+)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from io import StringIO
+from textwrap import dedent
 
 from django.core.management import call_command
 
@@ -14,3 +15,13 @@ def run_command(*args, **kwargs):
     except SystemExit as exc:  # pragma: no cover
         returncode = exc.code
     return out.getvalue(), err.getvalue(), returncode
+
+
+def empty_migration() -> str:
+    return dedent(
+        """
+        from django.db import migrations
+        class Migration(migrations.Migration):
+            pass
+        """
+    )


### PR DESCRIPTION
Fix #161

What do you think @adamchainz? It also seems using MigrationLoader needs proper fake migrations (with `Migration` class, not just empty files)