### PR TITLE
Move from isort to reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,16 @@ repos:
   - id: blacken-docs
     additional_dependencies:
     - black==22.10.0
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v3.9.0
   hooks:
-  - id: isort
+  - id: reorder-python-imports
+    args:
+    - --py37-plus
+    - --application-directories
+    - .:example:src
+    - --add-import
+    - 'from __future__ import annotations'
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 target-version = ['py37']
 
-[tool.isort]
-profile = "black"
-add_imports = "from __future__ import annotations"
-
 [tool.mypy]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/src/django_linear_migrations/apps.py
+++ b/src/django_linear_migrations/apps.py
@@ -2,14 +2,19 @@ from __future__ import annotations
 
 import pkgutil
 from functools import lru_cache
-from importlib import import_module, reload
+from importlib import import_module
+from importlib import reload
 from pathlib import Path
 from types import ModuleType
-from typing import Generator, Iterable
+from typing import Generator
+from typing import Iterable
 
-from django.apps import AppConfig, apps
+from django.apps import AppConfig
+from django.apps import apps
 from django.conf import settings
-from django.core.checks import Error, Tags, register
+from django.core.checks import Error
+from django.core.checks import register
+from django.core.checks import Tags
 from django.core.signals import setting_changed
 from django.db.migrations.loader import MigrationLoader
 from django.dispatch import receiver

--- a/src/django_linear_migrations/management/commands/create_max_migration_files.py
+++ b/src/django_linear_migrations/management/commands/create_max_migration_files.py
@@ -7,7 +7,8 @@ from typing import Any
 from django.apps import apps
 from django.core.management.commands.makemigrations import Command as BaseCommand
 
-from django_linear_migrations.apps import MigrationDetails, first_party_app_configs
+from django_linear_migrations.apps import first_party_app_configs
+from django_linear_migrations.apps import MigrationDetails
 
 
 class Command(BaseCommand):

--- a/src/django_linear_migrations/management/commands/makemigrations.py
+++ b/src/django_linear_migrations/management/commands/makemigrations.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from django.core.management.commands.makemigrations import Command as BaseCommand
 from django.db.migrations import Migration
 
-from django_linear_migrations.apps import MigrationDetails, first_party_app_configs
+from django_linear_migrations.apps import first_party_app_configs
+from django_linear_migrations.apps import MigrationDetails
 
 
 class Command(BaseCommand):

--- a/src/django_linear_migrations/management/commands/rebase_migration.py
+++ b/src/django_linear_migrations/management/commands/rebase_migration.py
@@ -9,18 +9,19 @@ from pathlib import Path
 from typing import Any
 
 from django.apps import apps
-from django.core.management import BaseCommand, CommandError
-from django.db import DatabaseError, connections
+from django.core.management import BaseCommand
+from django.core.management import CommandError
+from django.db import connections
+from django.db import DatabaseError
 from django.db.migrations.recorder import MigrationRecorder
 
-from django_linear_migrations.apps import MigrationDetails, is_first_party_app_config
-from django_linear_migrations.compat import (
-    ast_constant_type,
-    ast_unparse,
-    get_ast_constant_str_value,
-    is_ast_constant_str,
-    make_ast_constant_str,
-)
+from django_linear_migrations.apps import is_first_party_app_config
+from django_linear_migrations.apps import MigrationDetails
+from django_linear_migrations.compat import ast_constant_type
+from django_linear_migrations.compat import ast_unparse
+from django_linear_migrations.compat import get_ast_constant_str_value
+from django_linear_migrations.compat import is_ast_constant_str
+from django_linear_migrations.compat import make_ast_constant_str
 
 
 class Command(BaseCommand):

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -4,7 +4,8 @@ import sys
 import time
 
 import pytest
-from django.test import SimpleTestCase, override_settings
+from django.test import override_settings
+from django.test import SimpleTestCase
 
 from django_linear_migrations.apps import check_max_migration_files
 

--- a/tests/test_create_max_migration_files.py
+++ b/tests/test_create_max_migration_files.py
@@ -6,7 +6,8 @@ from io import StringIO
 
 import pytest
 from django.core.management import call_command
-from django.test import TestCase, override_settings
+from django.test import override_settings
+from django.test import TestCase
 
 
 class CreateMaxMigrationFilesTests(TestCase):

--- a/tests/test_makemigrations.py
+++ b/tests/test_makemigrations.py
@@ -6,7 +6,8 @@ from functools import partial
 from textwrap import dedent
 
 import pytest
-from django.test import TestCase, override_settings
+from django.test import override_settings
+from django.test import TestCase
 
 from tests.utils import run_command
 

--- a/tests/test_rebase_migration.py
+++ b/tests/test_rebase_migration.py
@@ -10,7 +10,9 @@ import pytest
 from django.core.management import CommandError
 from django.db import connection
 from django.db.migrations.recorder import MigrationRecorder
-from django.test import SimpleTestCase, TestCase, override_settings
+from django.test import override_settings
+from django.test import SimpleTestCase
+from django.test import TestCase
 
 from django_linear_migrations.management.commands import rebase_migration as module
 from tests.utils import run_command


### PR DESCRIPTION
It’s [way faster](https://twitter.com/codewithanthony/status/1553034384206438401) and its one-import-per-line style prevents merge conflicts.
