### PR TITLE
Fix FutureWarnings on Python 3.13

### DIFF
--- a/tests/test_makemigrations.py
+++ b/tests/test_makemigrations.py
@@ -16,7 +16,7 @@ class MakeMigrationsTests(EnterContextMixin, TestCase):
     def setUp(self):
         self.migrations_dir = self.enterContext(temp_migrations_module())
 
-    call_command = partial(run_command, "makemigrations")
+    call_command = staticmethod(partial(run_command, "makemigrations"))
 
     def test_dry_run(self):
         out, err, returncode = self.call_command("--dry-run", "testapp")

--- a/tests/test_rebase_migration.py
+++ b/tests/test_rebase_migration.py
@@ -36,7 +36,7 @@ class RebaseMigrationsTests(TestCase):
         finally:
             sys.path.pop(0)
 
-    call_command = partial(run_command, "rebase_migration")
+    call_command = staticmethod(partial(run_command, "rebase_migration"))
 
     def test_error_for_non_first_party_app(self):
         with mock.patch.object(module, "is_first_party_app_config", return_value=False):

--- a/tests/test_squashmigrations.py
+++ b/tests/test_squashmigrations.py
@@ -17,7 +17,7 @@ class SquashMigrationsTests(EnterContextMixin, TestCase):
     def setUp(self):
         self.migrations_dir = self.enterContext(temp_migrations_module())
 
-    call_command = partial(run_command, "squashmigrations")
+    call_command = staticmethod(partial(run_command, "squashmigrations"))
 
     def test_fail_already_squashed_migration(self):
         (self.migrations_dir / "__init__.py").touch()


### PR DESCRIPTION
This one:

```
FutureWarning: functools.partial will be a method descriptor in future Python versions; wrap it in staticmethod() if you want to preserve the old behavior
```